### PR TITLE
swagger docs autogeneration

### DIFF
--- a/server/core/pom.xml
+++ b/server/core/pom.xml
@@ -131,6 +131,13 @@
             <version>2.0.1</version>
         </dependency>
 
+        <!-- Swagger dependencies -->
+        <dependency>
+          <groupId>io.swagger</groupId>
+          <artifactId>swagger-jersey2-jaxrs</artifactId>
+          <version>1.5.12</version>
+        </dependency>
+
         <!-- MongoDB dependencies -->
         <dependency>
             <groupId>org.mongodb</groupId>

--- a/server/core/src/main/java/com/redhat/thermostat/server/core/internal/web/http/BaseHttpHandler.java
+++ b/server/core/src/main/java/com/redhat/thermostat/server/core/internal/web/http/BaseHttpHandler.java
@@ -10,8 +10,10 @@ import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.SecurityContext;
+import io.swagger.annotations.Api;
 
 @Path("/")
+@Api(value = "base")
 public class BaseHttpHandler {
 
     private final StorageHandler handler;

--- a/server/core/src/main/java/com/redhat/thermostat/server/core/internal/web/http/NamespaceHttpHandler.java
+++ b/server/core/src/main/java/com/redhat/thermostat/server/core/internal/web/http/NamespaceHttpHandler.java
@@ -8,8 +8,10 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.SecurityContext;
 
 import org.glassfish.jersey.server.ChunkedOutput;
+import io.swagger.annotations.Api;
 
 @Path("/api/v100/{namespace}")
+@Api(value = "namespace")
 public class NamespaceHttpHandler {
     private final StorageHandler handler;
 

--- a/server/core/src/main/java/com/redhat/thermostat/server/core/web/CustomResourceConfig.java
+++ b/server/core/src/main/java/com/redhat/thermostat/server/core/web/CustomResourceConfig.java
@@ -1,0 +1,24 @@
+package com.redhat.thermostat.server.core.web;
+
+import org.glassfish.jersey.server.ResourceConfig;
+import java.util.Map;
+import com.redhat.thermostat.server.core.internal.web.configuration.ServerConfiguration;
+import io.swagger.jaxrs.config.BeanConfig;
+
+public class CustomResourceConfig extends ResourceConfig {
+    public CustomResourceConfig(Map<String, String> serverConfig) {
+
+        if (serverConfig.containsKey(ServerConfiguration.SWAGGER_UI_ENABLED.toString()) &&
+                serverConfig.get(ServerConfiguration.SWAGGER_UI_ENABLED.toString()).equals("true")) {
+            BeanConfig beanConfig = new BeanConfig();
+            beanConfig.setBasePath("/");
+            beanConfig.setVersion("1.0.0");
+            beanConfig.setTitle("Thermostat Web API");
+            beanConfig.setLicense("GPL v2 with Classpath Exception");
+            beanConfig.setLicenseUrl("http://www.gnu.org/licenses");
+            // scan for JAX-RS classes from this package
+            beanConfig.setResourcePackage("com.redhat.thermostat.server.core.internal.web.http");
+            beanConfig.setScan(true);
+        }
+    }
+}

--- a/server/core/src/main/resources/swagger/index.html
+++ b/server/core/src/main/resources/swagger/index.html
@@ -37,7 +37,7 @@
         $.ajax(
             {
               type: 'GET',
-              url: "./swagger.json",
+              url: "/swagger.json",
               async: false,
               dataType: 'json'
             }


### PR DESCRIPTION
This commit adds the ability to autogenerate swagger docs (but really
swagger.json) by scanning through the JAX-RS classes (from package
'com.redhat.thermostat.server.core.internal.web.http') and using the
JAX-RS annotations to generate the swagger definitions.

The swagger generated is found in '/swagger.json'
![swagger1](https://cloud.githubusercontent.com/assets/630746/23732889/c2d1a77a-0443-11e7-8b11-18308033f492.png)


This feature is activated when the 'SWAGGER_UI_ENABLED' feature is
switched on.

To be able to activate the Swagger generation, I thought that it was
necessary to extend the `ResourceConfig` class to be able to create a
new `BeanConfig`, which is necessary to configure Swagger. In the
future, if a `web.xml` file is used instead, this code could be removed.

The relevant document was used to configure Swagger with Jersey for
auto-swagger doc generation:
https://github.com/swagger-api/swagger-core/wiki/Swagger-Core-Jersey-2.X-Project-Setup-1.5

The root web path for the swagger's index.html is also moved from
'/index.html' to '/apidocs' to avoid any naming collisions that might
happen.
![swagger2](https://cloud.githubusercontent.com/assets/630746/23732894/cd1387a8-0443-11e7-81ac-d5bb1031e230.png)
